### PR TITLE
Copy SDL_vulkan.h to framework. Remove DevelopmentTeam TargetAttributes.

### DIFF
--- a/Xcode/SDL/SDL.xcodeproj/project.pbxproj
+++ b/Xcode/SDL/SDL.xcodeproj/project.pbxproj
@@ -377,7 +377,7 @@
 		04F7805D12FB74A200FC43C0 /* SDL_drawline.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F7804512FB74A200FC43C0 /* SDL_drawline.h */; };
 		04F7805E12FB74A200FC43C0 /* SDL_drawpoint.c in Sources */ = {isa = PBXBuildFile; fileRef = 04F7804612FB74A200FC43C0 /* SDL_drawpoint.c */; };
 		04F7805F12FB74A200FC43C0 /* SDL_drawpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F7804712FB74A200FC43C0 /* SDL_drawpoint.h */; };
-		4D16644B1EDD5FE8003DE88E /* SDL_vulkan.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D16644A1EDD5FE8003DE88E /* SDL_vulkan.h */; };
+		4D16644B1EDD5FE8003DE88E /* SDL_vulkan.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D16644A1EDD5FE8003DE88E /* SDL_vulkan.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4D16644E1EDD6023003DE88E /* SDL_vulkan_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D16644C1EDD6023003DE88E /* SDL_vulkan_internal.h */; };
 		4D16644F1EDD6023003DE88E /* SDL_vulkan_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D16644D1EDD6023003DE88E /* SDL_vulkan_utils.c */; };
 		4D1664531EDD60AD003DE88E /* SDL_cocoametalview.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D1664501EDD60AD003DE88E /* SDL_cocoametalview.m */; };
@@ -1042,6 +1042,7 @@
 		4D1664521EDD60AD003DE88E /* SDL_cocoavulkan.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDL_cocoavulkan.m; sourceTree = "<group>"; };
 		4D16645D1EDD73E0003DE88E /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		4D1664611EDD74A9003DE88E /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		4D4820431F0F10B400EDC31C /* SDL_vulkan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SDL_vulkan.h; path = ../../include/SDL_vulkan.h; sourceTree = "<group>"; };
 		4D7517281EE2562B00820EEA /* SDL_cocoametalview.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_cocoametalview.h; sourceTree = "<group>"; };
 		56115BB91DF72C6D00F47E1E /* SDL_dataqueue.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SDL_dataqueue.c; path = ../../src/SDL_dataqueue.c; sourceTree = "<group>"; };
 		56115BBA1DF72C6D00F47E1E /* SDL_dataqueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SDL_dataqueue.h; path = ../../src/SDL_dataqueue.h; sourceTree = "<group>"; };
@@ -1703,6 +1704,7 @@
 		0867D691FE84028FC02AAC07 /* SDLFramework */ = {
 			isa = PBXGroup;
 			children = (
+				4D4820431F0F10B400EDC31C /* SDL_vulkan.h */,
 				F5A2EF3900C6A39A01000001 /* BUGS.txt */,
 				F59C70FC00D5CB5801000001 /* pkg-support */,
 				0153844A006D81B07F000001 /* Public Headers */,
@@ -1885,9 +1887,10 @@
 				AA7558541595D4D800BBD41B /* SDL_timer.h in Headers */,
 				AA7558561595D4D800BBD41B /* SDL_touch.h in Headers */,
 				AA7558581595D4D800BBD41B /* SDL_types.h in Headers */,
-				AA75585A1595D4D800BBD41B /* SDL_version.h in Headers */,
-				4D7517291EE2562B00820EEA /* SDL_cocoametalview.h in Headers */,
 				AA75585C1595D4D800BBD41B /* SDL_video.h in Headers */,
+				AA75585A1595D4D800BBD41B /* SDL_version.h in Headers */,
+				4D16644B1EDD5FE8003DE88E /* SDL_vulkan.h in Headers */,
+				4D7517291EE2562B00820EEA /* SDL_cocoametalview.h in Headers */,
 				04BD000912E6671800899322 /* SDL_diskaudio.h in Headers */,
 				04BD001112E6671800899322 /* SDL_dummyaudio.h in Headers */,
 				04BD001912E6671800899322 /* SDL_coreaudio.h in Headers */,
@@ -1957,7 +1960,6 @@
 				04BD01F312E6671800899322 /* SDL_x11sym.h in Headers */,
 				56A67021185654B40007D20F /* SDL_dynapi_procs.h in Headers */,
 				04BD01F512E6671800899322 /* SDL_x11touch.h in Headers */,
-				4D16644B1EDD5FE8003DE88E /* SDL_vulkan.h in Headers */,
 				04BD01F712E6671800899322 /* SDL_x11video.h in Headers */,
 				04BD01F912E6671800899322 /* SDL_x11window.h in Headers */,
 				041B2CA612FA0D680087D585 /* SDL_sysrender.h in Headers */,
@@ -2380,20 +2382,6 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0730;
-				TargetAttributes = {
-					BECDF5FE0761BA81005FE872 = {
-						DevelopmentTeam = UZ5V327NE3;
-					};
-					BECDF66D0761BA81005FE872 = {
-						DevelopmentTeam = UZ5V327NE3;
-					};
-					BECDF6BB0761BA81005FE872 = {
-						DevelopmentTeam = UZ5V327NE3;
-					};
-					DB313F7217554B71006C0E22 = {
-						DevelopmentTeam = UZ5V327NE3;
-					};
-				};
 			};
 			buildConfigurationList = 0073178E0858DB0500B2BC32 /* Build configuration list for PBXProject "SDL" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/docs/README-macosx.md
+++ b/docs/README-macosx.md
@@ -12,11 +12,10 @@ Preparation
 ===========
 
 1.  Either download [Molten](https://moltengl.com/free-trial/) and unzip it or download the Vulkan headers from Khronos's [Vulkan-Docs](https://github.com/KhronosGroup/Vulkan-Docs/tree/1.0/src/vulkan) repo and put them in a directory hierarchy `include/vulkan`.
-2. If you are going to use the command line set and export a `VULKAN_SDK` environment variable to the value described below.
-3. If you are going to use CMake either set and export a `VULKAN_SDK` environment variable before running `cmake` or set the `VULKAN_SDK` variable in `cmake-gui` and press *Configure*.
-4. If you are going to use the provided Xcode projects, set a `VULKAN_SDK` custom path in Xcode's preferences. Select *Custom Paths* on the *Locations* tab.
-
-The value of `VULKAN_SDK` should be either the `MoltenVK` directory within the unzipped Molten package or the parent of the `include/vulkan` hierarchy.
+2. Set a `VULKAN_SDK` variable in one of the ways described below. Its value should be either the `MoltenVK` directory within the unzipped Molten package or the parent of the `include/vulkan` hierarchy.
+	- If you are going to use the command line, set and export a `VULKAN_SDK` environment variable in your shell's start-up file, e.g. `.bash_profile`.
+	- If you are going to use CMake, either set and export a `VULKAN_SDK` environment variable before running `cmake` or set the `VULKAN_SDK` variable in `cmake-gui` and press *Configure*.
+	- If you are going to use the provided Xcode projects, set a `VULKAN_SDK` custom path in Xcode's preferences. Select *Custom Paths* on the *Locations* tab of preferences.
 
 Command Line Build
 ==================

--- a/docs/README-macosx.md
+++ b/docs/README-macosx.md
@@ -13,7 +13,7 @@ Preparation
 
 1.  Either download [Molten](https://moltengl.com/free-trial/) and unzip it or download the Vulkan headers from Khronos's [Vulkan-Docs](https://github.com/KhronosGroup/Vulkan-Docs/tree/1.0/src/vulkan) repo and put them in a directory hierarchy `include/vulkan`.
 2. Set a `VULKAN_SDK` variable in one of the ways described below. Its value should be either the `MoltenVK` directory within the unzipped Molten package or the parent of the `include/vulkan` hierarchy.
-	- If you are going to use the command line, set and export a `VULKAN_SDK` environment variable in your shell's start-up file, e.g. `.bash_profile`.
+	- If you are going to use the command line, set and export a `VULKAN_SDK` environment variable in your shell's start-up file, e.g. `~/.bash_profile`.
 	- If you are going to use CMake, either set and export a `VULKAN_SDK` environment variable before running `cmake` or set the `VULKAN_SDK` variable in `cmake-gui` and press *Configure*.
 	- If you are going to use the provided Xcode projects, set a `VULKAN_SDK` custom path in Xcode's preferences. Select *Custom Paths* on the *Locations* tab of preferences.
 


### PR DESCRIPTION
This fixes the Xcode project file so builds of the SDL framework include the new SDL_vulkan.h and removes references to my "DevelopmentTeam". It also cleans up docs/README-macosx.md so the preparation for build does not look more complex than it really is.