### PR TITLE
Don't specify Metal device for CAMetalLayer

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -4059,13 +4059,6 @@ void SDL_Vulkan_GetDrawableSize(SDL_Window * window, int *w, int *h)
     } else {
         SDL_GetWindowSize(window, w, h);
     }
-#if 0
-#if SDL_VIDEO_DRIVER_UIKIT
-    UIKit_Mtl_GetDrawableSize(window, w, h);
-#elif SDL_VIDEO_DRIVER_COCOA
-    Cocoa_Mtl_GetDrawableSize(window, w, h);
-#endif
-#endif
 }
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/cocoa/SDL_cocoametalview.h
+++ b/src/video/cocoa/SDL_cocoametalview.h
@@ -39,7 +39,6 @@
 #define METALVIEW_TAG 255
 
 @interface SDL_cocoametalview : NSView {
-    CAMetalLayer* _metalLayer;
     NSInteger _tag;
     bool _useHighDPI;
 }
@@ -47,14 +46,10 @@
 - (instancetype)initWithFrame:(NSRect)frame
                    useHighDPI:(bool)useHighDPI;
 
-@property (retain, nonatomic) CAMetalLayer *metalLayer;
 /* Override superclass tag so this class can set it. */
 @property (assign, readonly) NSInteger tag;
 
 @end
-
-int Cocoa_Mtl_LoadLibrary(const char *path);
-void Cocoa_Mtl_UnloadLibrary();
 
 SDL_cocoametalview* Cocoa_Mtl_AddMetalView(SDL_Window* window);
 

--- a/src/video/cocoa/SDL_cocoametalview.m
+++ b/src/video/cocoa/SDL_cocoametalview.m
@@ -143,20 +143,11 @@ Cocoa_Mtl_GetDrawableSize(SDL_Window * window, int * w, int * h)
     NSView *view = data->nswindow.contentView;
     SDL_cocoametalview* metalview = [view viewWithTag:METALVIEW_TAG];
     if (metalview) {
-#if 1
         CAMetalLayer *layer = (CAMetalLayer*)metalview.layer;
         assert(layer != NULL);
         if (w)
             *w = layer.drawableSize.width;
         if (h)
             *h = layer.drawableSize.height;
-#else
-        /* Fallback in case the above doesn't work. */
-        NSSize size = [view convertRectToBacking:[view bounds]].size;
-        if (w)
-            *w = size.width;
-        if (h)
-            *h = size.height;
-#endif
     }
 }

--- a/src/video/cocoa/SDL_cocoavulkan.m
+++ b/src/video/cocoa/SDL_cocoavulkan.m
@@ -130,9 +130,6 @@ int Cocoa_Vulkan_LoadLibrary(_THIS, const char *path)
                      VK_MVK_MACOS_SURFACE_EXTENSION_NAME "extension");
         goto fail;
     }
-    if (Cocoa_Mtl_LoadLibrary(NULL) < 0)
-        goto fail;
-    
     return 0;
 
 fail:
@@ -148,7 +145,6 @@ void Cocoa_Vulkan_UnloadLibrary(_THIS)
         if (_this->vulkan_config.loader_handle != DEFAULT_HANDLE)
             SDL_UnloadObject(_this->vulkan_config.loader_handle);
         _this->vulkan_config.loader_handle = NULL;
-        Cocoa_Mtl_UnloadLibrary();
     }
 }
 

--- a/src/video/uikit/SDL_uikitmetalview.h
+++ b/src/video/uikit/SDL_uikitmetalview.h
@@ -44,12 +44,7 @@
                         scale:(CGFloat)scale
                         tag:(int)tag;
 
-@property (retain, nonatomic) CAMetalLayer *metalLayer;
-
 @end
-
-int UIKit_Mtl_LoadLibrary(const char *path);
-void UIKit_Mtl_UnloadLibrary();
 
 SDL_uikitmetalview* UIKit_Mtl_AddMetalView(SDL_Window* window);
 

--- a/src/video/uikit/SDL_uikitvulkan.m
+++ b/src/video/uikit/SDL_uikitvulkan.m
@@ -134,8 +134,6 @@ int UIKit_Vulkan_LoadLibrary(_THIS, const char *path)
                      VK_MVK_IOS_SURFACE_EXTENSION_NAME "extension");
         goto fail;
     }
-    if (UIKit_Mtl_LoadLibrary(NULL) < 0)
-        goto fail;
 
     return 0;
 
@@ -151,7 +149,6 @@ void UIKit_Vulkan_UnloadLibrary(_THIS)
         if (_this->vulkan_config.loader_handle != DEFAULT_HANDLE)
             SDL_UnloadObject(_this->vulkan_config.loader_handle);
         _this->vulkan_config.loader_handle = NULL;
-        UIKit_Mtl_UnloadLibrary();
     }
 }
 


### PR DESCRIPTION
This fixes the issue raised by Alex in [bug 3591](https://bugzilla.libsdl.org/show_bug.cgi?id=3591) re calling MtlCreateSystemDefaultDevice() when creating a surface for iOS & macOS. The macOS change needs more testing. I do not have access to a Metal-capable Mac at present. Unfortunately the Vulkan test has not yet been added to the SDLTest Xcode project making testing by others a bit more difficult.

I don't understand why https://github.com/msc-/SDL-jake/commit/4710ea69fd67fd2c07c007e0f963a9dad1dd58cd still shows up here. I thought you'd merged my previous PR for that. It seems you did but when I pulled from you (my upstream) it shows a different commit id, bdaf437e3, for that change leading to the merge you can see and 2 commits in my git log for "Remove dead code".  Yuck!!